### PR TITLE
Fix tests and use a "Body" field for all request bodies

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,13 +142,13 @@ func main2() error {
 			// Get request body
 			if op.RequestBody != nil && op.RequestBody.Value.Content["application/json"] != nil {
 				if schema := op.RequestBody.Value.Content["application/json"].Schema; schema != nil {
-					def := schemaRefParse(schema, "Body")
+					def := schemaRefParse(schema, "")
 					p := templates.Definition{
-						Name:    def.Name,
+						Name:    "Body",
 						Tag:     "`httprequest:\",body\"`",
 						TypeStr: def.Name,
 					}
-					if def.Name == "Body" {
+					if def.Name == "" {
 						// If the request body is not a referenced type and is instead defined inline,
 						// we need to build the request type
 						reqBody := def

--- a/testdata/request.txt
+++ b/testdata/request.txt
@@ -68,5 +68,5 @@ type PostResponse struct {
 
 type PostTestDataRequest struct {
 	httprequest.Route `httprequest:"POST /test"`
-	PostRequest       PostRequest `httprequest:",body"`
+	Body              PostRequest `httprequest:",body"`
 }


### PR DESCRIPTION
This fixes a broken test (oops!) and also sets all request bodies to a `Body` field like so:
```
package params

import (
	httprequest "gopkg.in/httprequest.v1"
)

type APIHandler interface {
	Foo(httprequest.Params, *FooRequest) (*FooResponse, error)
}

type FooBody struct {
	Os Os `json:"os"`
}

type OS struct {
	X string `json:"x"`
}

type FooRequest struct {
	httprequest.Route `httprequest:"POST /somewhere"`
	Body              FooBody `httprequest:",body"`
}
```