### PR TITLE
Use flag for params file output.

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	outputDir      = gnuflag.String("outputdir", "", "The output directory to save generated server package (default: the current directory, or a temporary directory if --http is specified")
 	listenAddr     = gnuflag.String("http", "", "Implies --server. If set, the generated server will be run on the given network address (e.g. localhost:8088)")
 	packageName    = gnuflag.String("pkg", "params", "Package name to use for generated files (ignored if --server is specified)")
+	paramsFile     = gnuflag.String("o", "api-params.go", "File name to use for generated httprequest params.")
 	generateServer = gnuflag.Bool("server", false, "Generate server code (overwrites --pkg=main)")
 )
 
@@ -88,6 +89,7 @@ func main2() error {
 	arg := templates.TemplateArg{
 		GenerateServer: *generateServer,
 		Pkg:            *packageName,
+		ParamsFile:     *paramsFile,
 	}
 
 	// Build references of top level schema definitions

--- a/templates/template.go
+++ b/templates/template.go
@@ -16,6 +16,7 @@ type TemplateArg struct {
 	Pkg            string
 	Types          DefinitionList
 	Handlers       HandlerList
+	ParamsFile     string
 	GenerateServer bool
 }
 
@@ -24,7 +25,7 @@ func WriteAll(outputDir string, args TemplateArg) error {
 	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
 		os.Mkdir(outputDir, os.ModePerm)
 	}
-	err := Write(Params, args, filepath.Join(outputDir, "api-params.go"))
+	err := Write(Params, args, filepath.Join(outputDir, args.ParamsFile))
 	if err != nil {
 		return errgo.Notef(err, "cannot write api-params.go template")
 	}


### PR DESCRIPTION
This would allow using multiple openapi definition files in a single server.